### PR TITLE
+ Check only newcomers. close #5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ val utilDeps = Seq(
 lazy val silencer = project
   .in(file("."))
   .settings(commonSettings)
-  .settings(fork := true)
   .settings(libraryDependencies ++= Seq(
     "info.mukel"    %% "telegrambot4s"      % "3.0.8",
     "net.openhft"   % "chronicle-map"       % "3.14.1",

--- a/src/main/protobuf/UserStatsScheme.proto
+++ b/src/main/protobuf/UserStatsScheme.proto
@@ -13,6 +13,7 @@ message UserChatStatsScheme {
     required ZonedDateTime firstAppearance = 1;
     required int32 amountOfMessages = 2;
     repeated GuiltPair offences = 3;
+    optional ZonedDateTime joiningDttm = 4;
 }
 
 message GuiltPair {

--- a/src/main/scala/me/optician_owl/silencer/model/Rule.scala
+++ b/src/main/scala/me/optician_owl/silencer/model/Rule.scala
@@ -7,21 +7,22 @@ trait Rule {
   def apply(facts: Facts): Verdict
 }
 
-object NoviceAndSpammer extends Rule {
+class NoviceAndSpammer(noviceBoundary: Int) extends Rule {
 
-  val userChatStatsMonoid: Monoid[UserChatStats] = Monoid[UserChatStats]
+  // ToDo Wrong responsibility. Rule shouldn't change statistics.
+  private val userChatStatsMonoid: Monoid[UserChatStats] = Monoid[UserChatStats]
 
   override def apply(facts: Facts): Verdict = {
     val chatStats = facts.userStats.chatStats.getOrElse(facts.chat.id, userChatStatsMonoid.empty)
 
     if (chatStats.joiningDttm.isDefined
         && facts.evidences.nonEmpty
-        && chatStats.amountOfMessages <= 3)
+        && chatStats.amountOfMessages <= noviceBoundary)
       Infringement(NonEmptyList(Spam, Nil))
     else Innocent
   }
 }
 
 object Rule {
-  val codex: List[Rule] = List(NoviceAndSpammer)
+  val codex: List[Rule] = List(new NoviceAndSpammer(3))
 }

--- a/src/main/scala/me/optician_owl/silencer/model/Rule.scala
+++ b/src/main/scala/me/optician_owl/silencer/model/Rule.scala
@@ -1,7 +1,5 @@
 package me.optician_owl.silencer.model
 
-import java.time.ZonedDateTime
-
 import cats.data.NonEmptyList
 import cats.kernel.Monoid
 
@@ -16,9 +14,9 @@ object NoviceAndSpammer extends Rule {
   override def apply(facts: Facts): Verdict = {
     val chatStats = facts.userStats.chatStats.getOrElse(facts.chat.id, userChatStatsMonoid.empty)
 
-    if (facts.evidences.nonEmpty &&
-        chatStats.amountOfMessages <= 3 &&
-        chatStats.firstAppearance.isAfter(ZonedDateTime.now().minusMonths(1)))
+    if (chatStats.joiningDttm.isDefined
+        && facts.evidences.nonEmpty
+        && chatStats.amountOfMessages <= 3)
       Infringement(NonEmptyList(Spam, Nil))
     else Innocent
   }

--- a/src/main/scala/me/optician_owl/silencer/model/UserChatStats.scala
+++ b/src/main/scala/me/optician_owl/silencer/model/UserChatStats.scala
@@ -9,7 +9,8 @@ import cats.syntax.semigroup._
 case class UserChatStats(
     firstAppearance: ZonedDateTime,
     amountOfMessages: Int,
-    offences: Map[Guilt, Int]) {
+    offences: Map[Guilt, Int],
+    joiningDttm: Option[ZonedDateTime]) {
 
   def newGuilt(xs: Seq[Guilt]): UserChatStats = this.copy(offences = offences ++ xs.map(_ -> 1))
 
@@ -19,13 +20,14 @@ case class UserChatStats(
 object UserChatStats {
 
   implicit val chatStatsMonoid: Monoid[UserChatStats] = new Monoid[UserChatStats] {
-    override def empty: UserChatStats = UserChatStats(ZonedDateTime.now, 0, Map.empty)
+    override def empty: UserChatStats = UserChatStats(ZonedDateTime.now, 0, Map.empty, None)
 
     override def combine(x: UserChatStats, y: UserChatStats): UserChatStats =
       UserChatStats(
         if (x.firstAppearance.isBefore(y.firstAppearance)) x.firstAppearance else y.firstAppearance,
         x.amountOfMessages + y.amountOfMessages,
-        x.offences |+| y.offences
+        x.offences |+| y.offences,
+        x.joiningDttm.orElse(y.joiningDttm)
       )
   }
 

--- a/src/main/scala/me/optician_owl/silencer/services/StatsService.scala
+++ b/src/main/scala/me/optician_owl/silencer/services/StatsService.scala
@@ -46,12 +46,14 @@ class StatsService extends StrictLogging {
     Bijection.build { (ucs: UserChatStats) =>
       UserChatStatsScheme(ucs.firstAppearance.as[ProtoZDT],
                           ucs.amountOfMessages,
-                          ucs.offences.map(_.as[GuiltPair]).toSeq)
+                          ucs.offences.map(_.as[GuiltPair]).toSeq,
+                          ucs.joiningDttm.map(_.as[ProtoZDT]))
     } { (ucss: UserChatStatsScheme) =>
       UserChatStats(
         ucss.firstAppearance.as[ZDT],
         ucss.amountOfMessages,
-        ucss.offences.map(_.as[(Guilt, Int)]).toMap
+        ucss.offences.map(_.as[(Guilt, Int)]).toMap,
+        ucss.joiningDttm.map(_.as[ZDT])
       )
     }
 
@@ -80,11 +82,11 @@ class StatsService extends StrictLogging {
 
   private val userStatsDBBuilder: ChronicleMapBuilder[Array[Byte], Array[Byte]] =
     ChronicleMapBuilder
-    .of(classOf[Array[Byte]], classOf[Array[Byte]])
-    .name("user-statistics")
-    .entries(2e6.toInt) // Just a guess
-    .averageKey(Array.fill(8)(1.toByte))
-    .averageValue(converter(userStatsM.empty))
+      .of(classOf[Array[Byte]], classOf[Array[Byte]])
+      .name("user-statistics")
+      .entries(2e6.toInt) // Just a guess
+      .averageKey(Array.fill(8)(1.toByte))
+      .averageValue(converter(userStatsM.empty))
 
   val userStatsStore: ChronicleMap[Array[Byte], Array[Byte]] =
     userStatsDBBuilder.createPersistedTo(File(Path("db/user-stats-store.db")).jfile)

--- a/src/main/scala/me/optician_owl/silencer/utils/Utils.scala
+++ b/src/main/scala/me/optician_owl/silencer/utils/Utils.scala
@@ -1,0 +1,10 @@
+package me.optician_owl.silencer.utils
+
+import java.time.{Instant, ZonedDateTime}
+import java.util.TimeZone
+
+object Utils {
+  def zonedDateTime(epochSeconds: Int): ZonedDateTime =
+    ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds),
+                            TimeZone.getDefault.toZoneId)
+}

--- a/src/test/scala/me/optician_owl/silencer/model/NoviceAndSpammerTest.scala
+++ b/src/test/scala/me/optician_owl/silencer/model/NoviceAndSpammerTest.scala
@@ -1,0 +1,48 @@
+package me.optician_owl.silencer.model
+
+import java.time.ZonedDateTime
+
+import cats.data.NonEmptyList
+import info.mukel.telegrambot4s.models.{Chat, ChatType}
+import org.scalatest.{FlatSpec, Matchers}
+
+class NoviceAndSpammerTest extends FlatSpec with Matchers {
+
+  behavior of "NoviceAndSpammerTest"
+
+  private val chatID = 1001L
+
+  val facts = Facts(_: UserStats, List(UrlLink), Chat(chatID, ChatType.Group))
+
+  def stats(userChatStats: UserChatStats): UserStats =
+    UserStats(ZonedDateTime.now, 2, Map(), Map(chatID -> userChatStats))
+
+  def chatStats(isNewbie: Boolean): UserChatStats = {
+    val time = ZonedDateTime.now
+    UserChatStats(time, 2, Map(), if (isNewbie) Some(time) else None)
+  }
+
+  private val factsFabric = facts compose stats compose chatStats
+
+  private val oldTimerFacts = factsFabric(false)
+  private val newbieFacts   = factsFabric(true)
+
+  val rule1 = new NoviceAndSpammer(2)
+  val rule2 = new NoviceAndSpammer(1)
+
+  it should "ignore old-timers and check novices" in {
+    rule1(oldTimerFacts) should be(Innocent)
+    rule1(newbieFacts) should be(Infringement(NonEmptyList(Spam, Nil)))
+  }
+
+  it should "ignore veterans (users who have amount of messages greater than novice boundary)" in {
+    rule1(newbieFacts) should be(Infringement(NonEmptyList(Spam, Nil)))
+    rule2(newbieFacts) should be(Innocent)
+  }
+
+  it should "judge using evidences" in {
+    rule1(newbieFacts) should be(Infringement(NonEmptyList(Spam, Nil)))
+    rule1(newbieFacts.copy(evidences = List())) should be(Innocent)
+  }
+
+}

--- a/src/test/scala/me/optician_owl/silencer/services/StatsServiceTest.scala
+++ b/src/test/scala/me/optician_owl/silencer/services/StatsServiceTest.scala
@@ -3,7 +3,7 @@ package me.optician_owl.silencer.services
 import java.time.ZonedDateTime
 
 import info.mukel.telegrambot4s.models.{Chat, ChatType}
-import me.optician_owl.silencer.model.{Spam, UserStats}
+import me.optician_owl.silencer.model.{Spam, UserChatStats, UserStats}
 import org.scalatest.{FlatSpec, Matchers}
 
 class StatsServiceTest extends FlatSpec with Matchers {
@@ -14,6 +14,9 @@ class StatsServiceTest extends FlatSpec with Matchers {
   private val usEmpty     = UserStats(ZonedDateTime.now, 0, Map.empty)
   private val us          = usEmpty.newMsg(chat)
   private val usWithGuilt = us.newGuilt(chat, Seq(Spam))
+  private val time        = ZonedDateTime.now
+  private val newcommer =
+    usEmpty.copy(chatStats = Map(412L -> UserChatStats(time, 0, Map(), Some(time))))
 
   it should "convert UserStats back and forward" in {
     service.converter.invert(service.converter(usEmpty)) should be(usEmpty)
@@ -21,16 +24,19 @@ class StatsServiceTest extends FlatSpec with Matchers {
     service.converter.invert(service.converter(us)) should not be usWithGuilt
     service.converter.invert(service.converter(us)) should not be usEmpty
     service.converter.invert(service.converter(usWithGuilt)) should be(usWithGuilt)
+    service.converter.invert(service.converter(newcommer)) should be(newcommer)
   }
 
   it should "persist and read UserStats" in {
     service.updateStats(42L, usEmpty)
     service.updateStats(43L, us)
     service.updateStats(44L, usWithGuilt)
+    service.updateStats(45L, newcommer)
 
-    service.stats(41L) should be (UserStats(ZonedDateTime.now, 0, Map.empty))
-    service.stats(42L) should be (usEmpty)
-    service.stats(43L) should be (us)
-    service.stats(44L) should be (usWithGuilt)
+    service.stats(41L) should be(UserStats(ZonedDateTime.now, 0, Map.empty))
+    service.stats(42L) should be(usEmpty)
+    service.stats(43L) should be(us)
+    service.stats(44L) should be(usWithGuilt)
+    service.stats(45L) should be(newcommer)
   }
 }


### PR DESCRIPTION
* New field in UserChatStats - date of joining a group. Optional: None for users joined before bot, Some(ZonedDateTime) otherwise.
* Distinct joining and other messages. When user joined a chat add UserChatStats if it's first time contact.
* Update rule to consider only newcomers (joiningDttm is Defined).
* Remove `fork := true` from build.sbt